### PR TITLE
macOS support refactor

### DIFF
--- a/JPEGOptimizer.lua
+++ b/JPEGOptimizer.lua
@@ -192,22 +192,23 @@ return {
 	end,
 	postProcessRenderedPhotos = function(functionContext, filterContext)
 
+		-- Define paths for external tools
 		local UPexiv2 = 'exiv2'
 		local UPImageMagick = 'magick'
-		local UPjpegrecompress = 'jpeg-recompress'
+		local UPjpegrecompress = 'jpeg-archive'
 		local UPjpegtran = 'jpegtran'
-
-		if WIN_ENV then
-			UPexiv2 = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, 'WIN'), 'exiv2'),UPexiv2) .. '.exe"'
-			UPImageMagick = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, 'WIN'), 'ImageMagick'),UPImageMagick) .. '.exe"'
-			UPjpegrecompress = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, 'WIN'), 'jpeg-archive'),UPjpegrecompress) .. '.exe"'
-			UPjpegtran = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, 'WIN'), 'mozjpeg'),UPjpegtran) .. '.exe"'
-		else
-			UPexiv2 = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, 'macOS'), 'exiv2'),UPexiv2) .. '"'
-			UPImageMagick = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, 'macOS'), 'ImageMagick'),UPImageMagick) .. '"'
-			UPjpegrecompress = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, 'macOS'), 'jpeg-archive'),UPjpegrecompress) .. '"'
-			UPjpegtran = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, 'macOS'), 'mozjpeg'),UPjpegtran) .. '"'
-		end
+		-- Define executable names for external tools
+		local UEexiv2 = 'exiv2' .. (WIN_ENV and '.exe' or '')
+		local UEImageMagick = MAC_ENV and 'convert' or 'ImageMagick.exe'
+		local UEjpegrecompress = 'jpeg-recompress' .. (WIN_ENV and '.exe' or '')
+		local UEjpegtran = 'jpegtran' .. (WIN_ENV and '.exe' or '')
+		-- Define platform-specific path for external tools
+		local PlatPath = MAC_ENV and 'macOS' or 'WIN'
+		-- Construct commands for external tools
+		UPexiv2 = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, PlatPath), UPexiv2), UEexiv2) .. '"'
+		UPImageMagick = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, PlatPath), UPImageMagick), UEImageMagick) .. '"'
+		UPjpegrecompress = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, PlatPath), UPjpegrecompress), UEjpegrecompress) .. '"'
+		UPjpegtran = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, PlatPath), UPjpegrecompress), UEjpegtran) .. '"'
 
 		local renditionOptions = {
 			filterSettings = function( renditionToSatisfy, exportSettings )

--- a/JPEGOptimizer.lua
+++ b/JPEGOptimizer.lua
@@ -194,9 +194,9 @@ return {
 
 		-- Define paths for external tools
 		local UPexiv2 = 'exiv2'
-		local UPImageMagick = 'magick'
+		local UPImageMagick = 'ImageMagick'
 		local UPjpegrecompress = 'jpeg-archive'
-		local UPjpegtran = 'jpegtran'
+		local UPjpegtran = 'mozjpeg'
 		-- Define executable names for external tools
 		local UEexiv2 = 'exiv2' .. (WIN_ENV and '.exe' or '')
 		local UEImageMagick = MAC_ENV and 'convert' or 'ImageMagick.exe'

--- a/JPEGOptimizer.lua
+++ b/JPEGOptimizer.lua
@@ -204,8 +204,13 @@ return {
 		local UEjpegtran = 'jpegtran' .. (WIN_ENV and '.exe' or '')
 		-- Define platform-specific path for external tools
 		local PlatPath = MAC_ENV and 'macOS' or 'WIN'
-		-- Construct commands for external tools
-		UPexiv2 = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, PlatPath), UPexiv2), UEexiv2) .. '"'
+		-- Construct commands for external tools (reusing path variables)
+		if MAC_ENV then
+			local ExivPath = LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, PlatPath), UPexiv2)
+			UPexiv2 = 'LD_LIBRARY_PATH="' .. ExivPath .. '" "' .. LrPathUtils.child(ExivPath, UEexiv2) .. '"'
+		else
+			UPexiv2 = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, PlatPath), UPexiv2), UEexiv2) .. '"'
+		end
 		UPImageMagick = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, PlatPath), UPImageMagick), UEImageMagick) .. '"'
 		UPjpegrecompress = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, PlatPath), UPjpegrecompress), UEjpegrecompress) .. '"'
 		UPjpegtran = '"' .. LrPathUtils.child(LrPathUtils.child(LrPathUtils.child(_PLUGIN.path, PlatPath), UPjpegrecompress), UEjpegtran) .. '"'

--- a/JPEGOptimizer.lua
+++ b/JPEGOptimizer.lua
@@ -248,7 +248,7 @@ return {
 					outputToLog('Recompress: ' .. CmdRecompress)
 					if LrTasks.execute(quote4Win(CmdRecompress)) ~= 0 then renditionToSatisfy:renditionIsDone(false, 'Error recompressing JPEG file.') end
 					if not filterContext.propertyTable.FTJO_StripMetadata then
-						local CmdInsertMetadata = UPexiv2 .. ' -q -f -iX "' .. ExpFileName .. '"'
+						local CmdInsertMetadata = UPexiv2 .. ' -q -f -iX "' .. ExpFileName .. '"' .. (MAC_ENV and ' 2>/dev/null')
 						outputToLog('Insert metadata: ' .. CmdInsertMetadata)
 						if LrTasks.execute(quote4Win(CmdInsertMetadata)) ~= 0 then renditionToSatisfy:renditionIsDone(false, 'Error importing XMP data.') end
 						LrFileUtils.delete(LrPathUtils.replaceExtension(ExpFileName, 'xmp'))


### PR DESCRIPTION
It's been a while since I looked at this, but hopefully this update will finally get things working smoothly again. Using a legacy version of _ImageMagick_ was the simplest way forward with this, as you rightly suggested in the other thread. I believe I've now ensured all macOS binaries are suitably independent and only reliant on standard system libraries, or bundled where required (_exiv2_).

This has been tested on LR 6.14 & 6.6 (classic), but not on anything more recent, although I don't see why it shouldn't work.

Here's the new [macOS-binaries](https://github.com/ftischhauser/JPEGOptimizer/files/2165179/macOS-binaries.zip) archive for deployment. (License/readme files are symlinked to the Windows versions, assuming each tool resides in like-named folders within the **WIN** folder adjacent to the **macOS** folder.)
